### PR TITLE
read roles from access token claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ On the server side, annotate protected controllers (either the class or individu
 - ```security.jwt.read-timeout-ms``` - HTTP request read timeout
 - ```security.jwt.required-claims``` - The claims that must be present on the JWT for it to be valid.  By default this is `"sub", "iat", "exp", "nbf", "cid", "jti"`
 - ```security.jwt.required-scopes``` - List of scopes that are required for all JWT endpoints in this app
+- ```security.jwt.accessTokenRoles``` - The name of the claim in the access token that contains the roles (will need to be set to `cognito:groups` when authentication is performed by coginto)
+- ```security.jwt.rolePrefix``` - The prefix to apply to the access token roles (eg. `ROLE_`)
+- ```security.jwt.roleToUppercase``` - Should the role be converted to upper case (default: `true`)
 
 ### ApiKey support
 - ```security.apikey.enabled``` - Defaults to false. True indicated the plugin should check for apikey on incoming requests.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ On the server side, annotate protected controllers (either the class or individu
 - ```security.jwt.read-timeout-ms``` - HTTP request read timeout
 - ```security.jwt.required-claims``` - The claims that must be present on the JWT for it to be valid.  By default this is `"sub", "iat", "exp", "nbf", "cid", "jti"`
 - ```security.jwt.required-scopes``` - List of scopes that are required for all JWT endpoints in this app
-- ```security.jwt.accessTokenRoles``` - The name of the claim in the access token that contains the roles (will need to be set to `cognito:groups` when authentication is performed by coginto)
+- ```security.jwt.roleAttributes``` - The name of the claim(s) that contain the roles
+- ```security.jwt.rolesFromAccessToken``` - should the role claims be read from the access_token (default: `false`)
 - ```security.jwt.rolePrefix``` - The prefix to apply to the access token roles (eg. `ROLE_`)
 - ```security.jwt.roleToUppercase``` - Should the role be converted to upper case (default: `true`)
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 }
 
-version "4.3.4-SNAPSHOT"
+version "4.3.5-SNAPSHOT"
 group "org.grails.plugins"
 
 apply plugin:"eclipse"

--- a/src/main/groovy/au/ala/org/ws/security/AlaWsSecurityGrailsPluginConfiguration.groovy
+++ b/src/main/groovy/au/ala/org/ws/security/AlaWsSecurityGrailsPluginConfiguration.groovy
@@ -106,6 +106,10 @@ class AlaWsSecurityGrailsPluginConfiguration {
         authenticator.requiredClaims = jwtProperties.requiredClaims
         authenticator.requiredScopes = jwtProperties.requiredScopes
 
+        authenticator.accessTokenRoleClaims = jwtProperties.accessTokenRoles
+        authenticator.rolePrefix = jwtProperties.rolePrefix
+        authenticator.roleToUppercase = jwtProperties.roleToUppercase
+
         return new AlaOidcClient(credentialsExtractor, authenticator)
     }
 

--- a/src/main/groovy/au/ala/org/ws/security/AlaWsSecurityGrailsPluginConfiguration.groovy
+++ b/src/main/groovy/au/ala/org/ws/security/AlaWsSecurityGrailsPluginConfiguration.groovy
@@ -106,7 +106,11 @@ class AlaWsSecurityGrailsPluginConfiguration {
         authenticator.requiredClaims = jwtProperties.requiredClaims
         authenticator.requiredScopes = jwtProperties.requiredScopes
 
-        authenticator.accessTokenRoleClaims = jwtProperties.accessTokenRoles
+        authenticator.rolesFromAccessToken = jwtProperties.rolesFromAccessToken
+        if (authenticator.accessTokenRoleClaims = jwtProperties.roleAttributes) {
+            authenticator.accessTokenRoleClaims = jwtProperties.roleAttributes
+        }
+
         authenticator.rolePrefix = jwtProperties.rolePrefix
         authenticator.roleToUppercase = jwtProperties.roleToUppercase
 

--- a/src/main/groovy/au/ala/org/ws/security/AlaWsSecurityGrailsPluginConfiguration.groovy
+++ b/src/main/groovy/au/ala/org/ws/security/AlaWsSecurityGrailsPluginConfiguration.groovy
@@ -107,7 +107,7 @@ class AlaWsSecurityGrailsPluginConfiguration {
         authenticator.requiredScopes = jwtProperties.requiredScopes
 
         authenticator.rolesFromAccessToken = jwtProperties.rolesFromAccessToken
-        if (authenticator.accessTokenRoleClaims = jwtProperties.roleAttributes) {
+        if (authenticator.rolesFromAccessToken) {
             authenticator.accessTokenRoleClaims = jwtProperties.roleAttributes
         }
 

--- a/src/main/groovy/au/org/ala/ws/security/authenticator/AlaOidcAuthenticator.groovy
+++ b/src/main/groovy/au/org/ala/ws/security/authenticator/AlaOidcAuthenticator.groovy
@@ -1,12 +1,10 @@
 package au.org.ala.ws.security.authenticator
 
-import au.org.ala.ws.security.JwtProperties
 import au.org.ala.ws.security.profile.AlaOidcUserProfile
 import au.org.ala.ws.security.profile.AlaUserProfile
 import com.nimbusds.jose.JOSEException
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.source.JWKSource
-import com.nimbusds.jose.jwk.source.RemoteJWKSet
 import com.nimbusds.jose.proc.BadJOSEException
 import com.nimbusds.jose.proc.JWSKeySelector
 import com.nimbusds.jose.proc.JWSVerificationKeySelector
@@ -23,7 +21,6 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 
 import groovy.util.logging.Slf4j
 import org.pac4j.core.authorization.generator.AuthorizationGenerator
-import org.pac4j.core.authorization.generator.FromAttributesAuthorizationGenerator
 import org.pac4j.core.context.WebContext
 import org.pac4j.core.context.session.SessionStore
 import org.pac4j.core.credentials.Credentials
@@ -34,12 +31,10 @@ import org.pac4j.core.util.CommonHelper
 import org.pac4j.oidc.config.OidcConfiguration
 import org.pac4j.oidc.credentials.OidcCredentials
 import org.pac4j.oidc.credentials.authenticator.UserInfoOidcAuthenticator
-import org.pac4j.oidc.profile.OidcProfile
-import org.pac4j.oidc.profile.OidcProfileDefinition
 
 import java.text.ParseException
-
-import static java.util.Optional.ofNullable
+import java.util.stream.Collectors
+import java.util.stream.Stream
 
 /**
  * Authenticator for JWT access_token based on the Pac4j {@link org.pac4j.oidc.credentials.authenticator.UserInfoOidcAuthenticator},
@@ -57,6 +52,10 @@ class AlaOidcAuthenticator extends UserInfoOidcAuthenticator {
 
     List<String> requiredClaims
     List<String> requiredScopes
+
+    List<String> accessTokenRoleClaims
+    String rolePrefix = ''
+    boolean roleToUppercase = true
 
     AlaOidcAuthenticator(final OidcConfiguration configuration) {
 
@@ -114,9 +113,13 @@ class AlaOidcAuthenticator extends UserInfoOidcAuthenticator {
                 new JWTClaimsSet.Builder().issuer(issuer.value).build(),
                 requiredClaims?.toSet())
 
+        Collection<String> accessTokenRoles
+
         try {
 
             JWTClaimsSet claimsSet = jwtProcessor.process(jwt, null)
+
+            accessTokenRoles = getRoles(claimsSet)
 
             Scope scope = Scope.parse(claimsSet.getClaim(OidcConfiguration.SCOPE))
             credentials.accessToken = new BearerAccessToken(accessToken, 0L, scope)
@@ -150,6 +153,17 @@ class AlaOidcAuthenticator extends UserInfoOidcAuthenticator {
             } else {
                 cred.userProfile = generateAlaUserProfile(profile)
             }
+
+            if (accessTokenRoles) {
+                cred.userProfile.addRoles(accessTokenRoles)
+            }
+
+        } else if (accessTokenRoles) {
+
+            AlaOidcUserProfile alaOidcUserProfile = new AlaOidcUserProfile()
+            alaOidcUserProfile.addRoles(accessTokenRoles)
+
+            cred.userProfile = alaOidcUserProfile
         }
     }
 
@@ -157,11 +171,40 @@ class AlaOidcAuthenticator extends UserInfoOidcAuthenticator {
 
         AlaOidcUserProfile alaOidcUserProfile = new AlaOidcUserProfile()
         alaOidcUserProfile.addAttributes(profile.attributes)
-
-        // session expiration with token behavior
-        alaOidcUserProfile.setTokenExpirationAdvance(configuration.getTokenExpirationAdvance())
+        alaOidcUserProfile.roles = profile.roles
+        alaOidcUserProfile.permissions = profile.permissions
 
         return alaOidcUserProfile
+    }
+
+    Collection<String> getRoles(JWTClaimsSet claimsSet) {
+
+        if (!accessTokenRoleClaims) {
+            return null
+        }
+
+        Stream<String> roles = accessTokenRoleClaims.stream()
+                .map(claimsSet::getClaim)
+                .filter(Objects::nonNull)
+                .flatMap { Object roleClaim ->
+                    if (roleClaim instanceof String) {
+                        Stream.of(roleClaim.split(','))
+                    } else if (roleClaim.getClass().isArray() && roleClaim.getClass().getComponentType().isAssignableFrom(String.class)) {
+                        Stream.of(roleClaim)
+                    } else if (Collection.class.isAssignableFrom(roleClaim.getClass())) {
+                        ((Collection) roleClaim).stream()
+                    }
+                }
+
+        if (this.rolePrefix) {
+            roles = roles.map { String role -> this.rolePrefix + role }
+        }
+
+        if (this.roleToUppercase) {
+            roles = roles.map { String role -> role.toUpperCase() }
+        }
+
+        return roles.collect(Collectors.toSet())
     }
 
     @Override

--- a/src/main/groovy/au/org/ala/ws/security/authenticator/AlaOidcAuthenticator.groovy
+++ b/src/main/groovy/au/org/ala/ws/security/authenticator/AlaOidcAuthenticator.groovy
@@ -54,6 +54,7 @@ class AlaOidcAuthenticator extends UserInfoOidcAuthenticator {
     List<String> requiredScopes
 
     List<String> accessTokenRoleClaims
+    boolean rolesFromAccessToken = false
     String rolePrefix = ''
     boolean roleToUppercase = true
 
@@ -179,8 +180,8 @@ class AlaOidcAuthenticator extends UserInfoOidcAuthenticator {
 
     Collection<String> getRoles(JWTClaimsSet claimsSet) {
 
-        if (!accessTokenRoleClaims) {
-            return null
+        if (!rolesFromAccessToken) {
+            return []
         }
 
         Stream<String> roles = accessTokenRoleClaims.stream()

--- a/src/main/java/au/org/ala/ws/security/JwtProperties.java
+++ b/src/main/java/au/org/ala/ws/security/JwtProperties.java
@@ -15,8 +15,13 @@ public class JwtProperties {
     private String jwtType = "jwt";
     private int connectTimeoutMs = HttpConstants.DEFAULT_CONNECT_TIMEOUT;;
     private int readTimeoutMs = HttpConstants.DEFAULT_READ_TIMEOUT;
+
+    private List<String> accessTokenRoles = List.of();
+    private String rolePrefix = "ROLE_";
+    private boolean roleToUppercase = true;
     private List<String> roleAttributes = List.of("role");
     private List<String> permissionAttributes = List.of("scope","scp", "scopes");
+
     private List<String> requiredClaims = List.of("sub", "iat", "exp", "client_id", "jti", "iss");
     private List<String> requiredScopes = List.of();
     private List<String> urlPatterns = List.of(); // hard coded paths to apply JWT authentication to
@@ -83,6 +88,30 @@ public class JwtProperties {
 
     public void setJwtType(String jwtType) {
         this.jwtType = jwtType;
+    }
+
+    public List<String> getAccessTokenRoles() {
+        return accessTokenRoles;
+    }
+
+    public void setAccessTokenRoles(List<String> accessTokenRoles) {
+        this.accessTokenRoles = accessTokenRoles;
+    }
+
+    public String getRolePrefix() {
+        return rolePrefix;
+    }
+
+    public void setRolePrefix(String rolePrefix) {
+        this.rolePrefix = rolePrefix;
+    }
+
+    public boolean isRoleToUppercase() {
+        return roleToUppercase;
+    }
+
+    public void setRoleToUppercase(boolean roleToUppercase) {
+        this.roleToUppercase = roleToUppercase;
     }
 
     public List<String> getRoleAttributes() {

--- a/src/main/java/au/org/ala/ws/security/JwtProperties.java
+++ b/src/main/java/au/org/ala/ws/security/JwtProperties.java
@@ -16,7 +16,7 @@ public class JwtProperties {
     private int connectTimeoutMs = HttpConstants.DEFAULT_CONNECT_TIMEOUT;;
     private int readTimeoutMs = HttpConstants.DEFAULT_READ_TIMEOUT;
 
-    private List<String> accessTokenRoles = List.of();
+    private boolean rolesFromAccessToken = false;
     private String rolePrefix = "ROLE_";
     private boolean roleToUppercase = true;
     private List<String> roleAttributes = List.of("role");
@@ -90,12 +90,12 @@ public class JwtProperties {
         this.jwtType = jwtType;
     }
 
-    public List<String> getAccessTokenRoles() {
-        return accessTokenRoles;
+    public boolean isRolesFromAccessToken() {
+        return rolesFromAccessToken;
     }
 
-    public void setAccessTokenRoles(List<String> accessTokenRoles) {
-        this.accessTokenRoles = accessTokenRoles;
+    public void setRolesFromAccessToken(boolean rolesFromAccessToken) {
+        this.rolesFromAccessToken = rolesFromAccessToken;
     }
 
     public String getRolePrefix() {

--- a/src/test/groovy/au/org/ala/ws/security/authenticator/AlaOidcAuthenticatorSpec.groovy
+++ b/src/test/groovy/au/org/ala/ws/security/authenticator/AlaOidcAuthenticatorSpec.groovy
@@ -17,7 +17,7 @@ import com.nimbusds.oauth2.sdk.Scope
 import com.nimbusds.oauth2.sdk.id.Issuer
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata
-
+import groovy.time.TimeCategory
 import org.pac4j.core.context.WebContext
 import org.pac4j.core.context.session.SessionStore
 import org.pac4j.core.exception.CredentialsException
@@ -93,6 +93,42 @@ class AlaOidcAuthenticatorSpec extends Specification {
         then:
         CredentialsException ce = thrown CredentialsException
         ce.message == 'access_token with scope \'[test/scope]\' is missing required scopes [required/scope]'
+    }
+
+    def 'validate access_token with roles'() {
+
+        setup:
+        OidcConfiguration oidcConfiguration = Mock()
+
+        AlaOidcAuthenticator alaOidcAuthenticator = new AlaOidcAuthenticator(oidcConfiguration)
+        alaOidcAuthenticator.issuer = new Issuer('http://localhost')
+        alaOidcAuthenticator.expectedJWSAlgs = [ JWSAlgorithm.RS256 ].toSet()
+        alaOidcAuthenticator.keySource = new ImmutableJWKSet<SecurityContext>(jwkSet)
+
+        alaOidcAuthenticator.accessTokenRoleClaims = [ 'roles' ]
+        alaOidcAuthenticator.rolePrefix = 'ROLE_'
+
+        OidcCredentials oidcCredentials = new OidcCredentials()
+        JWTClaimsSet jwtClaims = new JWTClaimsSet.Builder()
+                .subject('sub')
+                .issuer(alaOidcAuthenticator.issuer.value)
+                .notBeforeTime(new Date())
+                .expirationTime(use(TimeCategory) { new Date() + 1.minute })
+                .audience('aud')
+                .issueTime(new Date())
+                .claim('roles', [ 'user', 'admin' ])
+                .build()
+
+        oidcCredentials.accessToken = new BearerAccessToken(generateJwt(jwkSet, jwtClaims))
+
+        WebContext context = Mock()
+        SessionStore sessionStore = Mock()
+
+        when:
+        alaOidcAuthenticator.validate(oidcCredentials, context, sessionStore)
+
+        then:
+        oidcCredentials.userProfile.roles == Set.of('ROLE_USER', 'ROLE_ADMIN')
     }
 
     def 'validate access_token with user profile'() {

--- a/src/test/groovy/au/org/ala/ws/security/authenticator/AlaOidcAuthenticatorSpec.groovy
+++ b/src/test/groovy/au/org/ala/ws/security/authenticator/AlaOidcAuthenticatorSpec.groovy
@@ -1,6 +1,5 @@
 package au.org.ala.ws.security.authenticator
 
-import au.org.ala.ws.security.JwtProperties
 import au.org.ala.ws.security.profile.AlaOidcUserProfile
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.common.Json
@@ -8,7 +7,6 @@ import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet
 import com.nimbusds.jose.proc.SecurityContext
-import com.nimbusds.jose.util.ResourceRetriever
 import com.nimbusds.jwt.JWT
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.JWTParser
@@ -105,6 +103,7 @@ class AlaOidcAuthenticatorSpec extends Specification {
         alaOidcAuthenticator.expectedJWSAlgs = [ JWSAlgorithm.RS256 ].toSet()
         alaOidcAuthenticator.keySource = new ImmutableJWKSet<SecurityContext>(jwkSet)
 
+        alaOidcAuthenticator.rolesFromAccessToken = true
         alaOidcAuthenticator.accessTokenRoleClaims = [ 'roles' ]
         alaOidcAuthenticator.rolePrefix = 'ROLE_'
 


### PR DESCRIPTION
With the migration of the roles into coginto groups the groups are a claim on the access token. 

This PR allows the configuration of the OIDC / JWT authenticator to read the roles from the access token.

The config options are:
 - `security.jwt.accessTokenRoles` the name of the claim in the access token that contains the roles (will need to be set to `cognito:groups` when authentication is performed by coginto)
 - `security.jwt.rolePrefix` the prefix to apply to the access token roles (eg. `ROLE_`)
 - `security.jwt.roleToUppercase` should the role be converted to upper case (default: `true`)