### PR TITLE
UserId missing from the AlaUserProfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ On the server side, annotate protected controllers (either the class or individu
 - ```security.jwt.read-timeout-ms``` - HTTP request read timeout
 - ```security.jwt.required-claims``` - The claims that must be present on the JWT for it to be valid.  By default this is `"sub", "iat", "exp", "nbf", "cid", "jti"`
 - ```security.jwt.required-scopes``` - List of scopes that are required for all JWT endpoints in this app
-- ```security.jwt.roleAttributes``` - The name of the claim(s) that contain the roles
-- ```security.jwt.rolesFromAccessToken``` - should the role claims be read from the access_token (default: `false`)
-- ```security.jwt.rolePrefix``` - The prefix to apply to the access token roles (eg. `ROLE_`)
-- ```security.jwt.roleToUppercase``` - Should the role be converted to upper case (default: `true`)
+- ```security.jwt.user-id-claim``` - The claims from the access token that contains the userId (default: `userid`)
+- ```security.jwt.role-claims``` - The name of the claim(s) that contain the roles (default: `role`)
+- ```security.jwt.permission-claims``` - The name of the claims(s) that contain the permissions (default: `scope,scopes,scp`)
+- ```security.jwt.roles-from-access-token``` - should the role claims be read from the access_token (default: `true`)
+- ```security.jwt.role-prefix``` - The prefix to apply to the access token roles (eg. `ROLE_`)
+- ```security.jwt.role-to-uppercase``` - Should the role be converted to upper case (default: `true`)
 
 ### ApiKey support
 - ```security.apikey.enabled``` - Defaults to false. True indicated the plugin should check for apikey on incoming requests.

--- a/ala-ws-security/src/main/java/au/org/ala/ws/security/AlaWsSecurityConfiguration.java
+++ b/ala-ws-security/src/main/java/au/org/ala/ws/security/AlaWsSecurityConfiguration.java
@@ -131,14 +131,15 @@ public class AlaWsSecurityConfiguration {
         authenticator.setExpectedJWSAlgs(Set.copyOf(providerMetadata.getIDTokenJWSAlgs()));
 
         authenticator.setKeySource(jwkSource);
-        authenticator.setAuthorizationGenerator(new FromAttributesAuthorizationGenerator(jwtProperties.getRoleAttributes(), jwtProperties.getPermissionAttributes()));
+        authenticator.setAuthorizationGenerator(new FromAttributesAuthorizationGenerator(jwtProperties.getRoleClaims(), jwtProperties.getPermissionClaims()));
 
+        authenticator.setUserIdClaim(jwtProperties.getUserIdClaim());
         authenticator.setRequiredClaims(jwtProperties.getRequiredClaims());
         authenticator.setRequiredScopes(jwtProperties.getRequiredScopes());
 
         authenticator.setRolesFromAccessToken(jwtProperties.isRolesFromAccessToken());
         if (authenticator.isRolesFromAccessToken()) {
-            authenticator.setAccessTokenRoleClaims(jwtProperties.getRoleAttributes());
+            authenticator.setAccessTokenRoleClaims(jwtProperties.getRoleClaims());
         }
 
         authenticator.setRolePrefix(jwtProperties.getRolePrefix());

--- a/ala-ws-security/src/main/java/au/org/ala/ws/security/JwtProperties.java
+++ b/ala-ws-security/src/main/java/au/org/ala/ws/security/JwtProperties.java
@@ -16,12 +16,13 @@ public class JwtProperties {
     private int connectTimeoutMs = HttpConstants.DEFAULT_CONNECT_TIMEOUT;;
     private int readTimeoutMs = HttpConstants.DEFAULT_READ_TIMEOUT;
 
-    private boolean rolesFromAccessToken = false;
+    private boolean rolesFromAccessToken = true;
     private String rolePrefix = "ROLE_";
     private boolean roleToUppercase = true;
-    private List<String> roleAttributes = List.of("role");
-    private List<String> permissionAttributes = List.of("scope","scp", "scopes");
+    private List<String> roleClaims = List.of("role");
+    private List<String> permissionClaims = List.of("scope","scp", "scopes");
 
+    private String userIdClaim = "userid";
     private List<String> requiredClaims = List.of("sub", "iat", "exp", "client_id", "jti", "iss");
     private List<String> requiredScopes = List.of();
     private List<String> urlPatterns = List.of(); // hard coded paths to apply JWT authentication to
@@ -114,20 +115,38 @@ public class JwtProperties {
         this.roleToUppercase = roleToUppercase;
     }
 
-    public List<String> getRoleAttributes() {
-        return roleAttributes;
+    public List<String> getRoleClaims() {
+        return roleClaims;
     }
 
-    public void setRoleAttributes(List<String> roleAttributes) {
-        this.roleAttributes = roleAttributes;
+    @Deprecated
+    public void setRoleAttributes(List<String> roleClaims) {
+        this.roleClaims = roleClaims;
     }
 
-    public List<String> getPermissionAttributes() {
-        return permissionAttributes;
+    public void setRoleClaims(List<String> roleClaims) {
+        this.roleClaims = roleClaims;
     }
 
-    public void setPermissionAttributes(List<String> permissionAttributes) {
-        this.permissionAttributes = permissionAttributes;
+    public List<String> getPermissionClaims() {
+        return permissionClaims;
+    }
+
+    public void setPermissionAttibutes(List<String> permissionClaims) {
+        this.permissionClaims = permissionClaims;
+    }
+
+    @Deprecated
+    public void setPermissionClaims(List<String> permissionClaims) {
+        this.permissionClaims = permissionClaims;
+    }
+
+    public String getUserIdClaim() {
+        return userIdClaim;
+    }
+
+    public void setUserIdClaim(String userIdClaim) {
+        this.userIdClaim = userIdClaim;
     }
 
     public List<String> getRequiredClaims() {

--- a/ala-ws-security/src/main/java/au/org/ala/ws/security/profile/AlaOidcUserProfile.java
+++ b/ala-ws-security/src/main/java/au/org/ala/ws/security/profile/AlaOidcUserProfile.java
@@ -2,7 +2,21 @@ package au.org.ala.ws.security.profile;
 
 import org.pac4j.oidc.profile.OidcProfile;
 
+import java.security.Principal;
+
 public class AlaOidcUserProfile extends OidcProfile implements AlaUserProfile {
+
+    final String userId;
+
+    public AlaOidcUserProfile(String userId) {
+        this.userId = userId;
+    }
+
+    @Override
+    public String getUserId() {
+        return userId;
+    }
+
     @Override
     public String getName() {
         return this.getDisplayName();
@@ -13,4 +27,8 @@ public class AlaOidcUserProfile extends OidcProfile implements AlaUserProfile {
         return super.getFirstName();
     }
 
+    @Override
+    public Principal asPrincipal() {
+        return this;
+    }
 }

--- a/ala-ws-security/src/main/java/au/org/ala/ws/security/profile/AlaUserProfile.java
+++ b/ala-ws-security/src/main/java/au/org/ala/ws/security/profile/AlaUserProfile.java
@@ -5,6 +5,9 @@ import org.pac4j.core.profile.UserProfile;
 import java.security.Principal;
 
 public interface AlaUserProfile extends Principal, UserProfile {
+
+    String getUserId();
+
     String getEmail();
 
     String getGivenName();


### PR DESCRIPTION
Added `userId` to the `AlaUserProfile` interface.

The userId is retrieved from `security.jwt.user-id-claim` the access token and populated in `AlaOidcUserProfile`.
`AlaOidcUserProfile::asPrincipal`now returns self.

Renamed the configuration `roleAttributes` and `permissionAttributes` to `roleClaims` and `permissionClaims` to keep consistence. Configuration setters are still available for backward compatibility. 

