### PR TITLE
Feature/handle missing OIDC auth state

### DIFF
--- a/ala-auth/src/main/groovy/au/org/ala/web/config/AuthPac4jPluginConfig.groovy
+++ b/ala-auth/src/main/groovy/au/org/ala/web/config/AuthPac4jPluginConfig.groovy
@@ -1,6 +1,7 @@
 package au.org.ala.web.config
 
 import au.org.ala.pac4j.core.logout.RemoveCookieLogoutActionBuilder
+import au.org.ala.pac4j.oidc.credentials.extractor.CognitoOidcExtractor
 import au.org.ala.web.AffiliationSurveyFilter
 import au.org.ala.web.AuthCookieProperties
 import au.org.ala.web.CasClientProperties
@@ -169,6 +170,7 @@ class AuthPac4jPluginConfig {
     OidcClient oidcClient(OidcConfiguration oidcConfiguration, CookieGenerator authCookieGenerator) {
         def client = createOidcClientFromConfig(oidcConfiguration, authCookieGenerator)
         client.setName(DEFAULT_CLIENT)
+        client.setCredentialsExtractor(new CognitoOidcExtractor(oidcConfiguration, client))
         return client
     }
 

--- a/ala-auth/src/main/java/au/org/ala/pac4j/oidc/credentials/extractor/CognitoOidcExtractor.java
+++ b/ala-auth/src/main/java/au/org/ala/pac4j/oidc/credentials/extractor/CognitoOidcExtractor.java
@@ -31,8 +31,7 @@ public class CognitoOidcExtractor extends OidcExtractor {
         } catch (TechnicalException te) {
 
             if (te.getMessage().equals("State cannot be determined")) {
-
-//                sessionStore.set(context, Pac4jConstants.REQUESTED_URL, requestedUrl);
+                
                 // redirect to the authentication page
                 throw client.getRedirectionAction(context, sessionStore).get();
             }

--- a/ala-auth/src/main/java/au/org/ala/pac4j/oidc/credentials/extractor/CognitoOidcExtractor.java
+++ b/ala-auth/src/main/java/au/org/ala/pac4j/oidc/credentials/extractor/CognitoOidcExtractor.java
@@ -1,0 +1,44 @@
+package au.org.ala.pac4j.oidc.credentials.extractor;
+
+import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.credentials.extractor.OidcExtractor;
+
+import java.util.Optional;
+
+/**
+ * Wrapper for the <code>OidcExtractor</code> to handle the missing state.
+ *
+ * This occurs if there is an issue after Cognito authentication but before the app callback has processed
+ * authentication code and redirected to the secure page.
+ * This has proven to be an issue if the user re-clicked on the login button during the callback processing.
+ */
+public class CognitoOidcExtractor extends OidcExtractor {
+
+    public CognitoOidcExtractor(OidcConfiguration configuration, OidcClient client) {
+        super(configuration, client);
+    }
+
+    @Override
+    public Optional<Credentials> extract(WebContext context, SessionStore sessionStore) {
+        try {
+            return super.extract(context, sessionStore);
+        } catch (TechnicalException te) {
+
+            if (te.getMessage().equals("State cannot be determined")) {
+
+//                sessionStore.set(context, Pac4jConstants.REQUESTED_URL, requestedUrl);
+                // redirect to the authentication page
+                throw client.getRedirectionAction(context, sessionStore).get();
+            }
+
+            throw te;
+        }
+    }
+}
+


### PR DESCRIPTION
This change addresses an issue with the Cognito when a user double clicks the login button (see: AtlasOfLivingAustralia/cognito#193)

If this double click during the processing of the authentication callback to exchange the auth code for an access token then the login fails. If the user reinitiates the authentication process then the subsequent call the app callback has previously cleared the initial auth requests `state` property causing the new callback to fail with a `TechnicalException: State cannot be determined`.

This change wraps the `CredentialExtractor` to catch the exception and redirect back to the auth. 