### PR TITLE
Add ability to configure @RequireApiKey scopes per deployment #45

### DIFF
--- a/ala-auth/grails-app/services/au/org/ala/web/AuthService.groovy
+++ b/ala-auth/grails-app/services/au/org/ala/web/AuthService.groovy
@@ -3,12 +3,16 @@ package au.org.ala.web
 import au.org.ala.userdetails.UserDetailsClient
 import au.org.ala.userdetails.UserDetailsFromIdListRequest
 import au.org.ala.userdetails.UserDetailsFromIdListResponse
+import grails.plugin.cache.CacheEvict
 import grails.plugin.cache.Cacheable
 import grails.web.mapping.LinkGenerator
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
 
 import javax.servlet.http.HttpServletRequest
 
+@Slf4j
 class AuthService implements IAuthService {
 
     static transactional = false
@@ -22,6 +26,9 @@ class AuthService implements IAuthService {
 
     @Autowired
     LinkGenerator linkGenerator
+
+    @Autowired(required = false)
+    CacheManager cacheManager
 
     String getEmail() {
         delegateService.getEmail()
@@ -69,6 +76,16 @@ class AuthService implements IAuthService {
 
     UserDetails getUserForUserId(String userId, boolean includeProps = true) {
         return getUserForUserIdInternal(userId, includeProps).orElse(null)
+    }
+
+    @CacheEvict(value='userDetailsCache', allEntries = true)
+    def clearUserDetailsCache() {
+        log.info("Clearing userDetailsCache")
+    }
+
+    @CacheEvict(value='userDetailsByIdCache', allEntries = true)
+    def clearUserDetailsByIdCache() {
+        log.info("Clearing userDetailsByIdCache")
     }
 
     @Cacheable("userDetailsCache")

--- a/ala-ws-security-plugin/README.md
+++ b/ala-ws-security-plugin/README.md
@@ -18,7 +18,15 @@ On the server side, the legacy `@RequireApiKey` annotations will still be honour
 look for a JWT in the request first before optionally falling back to the legacy behaviour.
 
 Optionally, you may add a `scopes` parameter to the `@RequireApiKey` annotation, to enforce incoming JWT
-requests to have the given scopes (ie, an app might have a `read:appname` scope defined for reading from its API)
+requests to have the given scopes (ie, an app might have a `appname/read` scope defined for reading from its API).
+For the case where scopes shouldn't be hard coded in to the application, the `scopesFromProperty` parameter on
+`@RequireApiKey` can be set, and the scopes will be read from the given configuration property.
+
+Additionally, a custom filter can be defined to implement custom business logic for authorising requests.  To do so,
+simply define a bean of type `au.org.ala.ws.security.filter.RequireApiKeyFilter` in your application context.  This
+filter is called after the JWT has been validated, and before the request is passed to the controller.  To access
+the parsed JWT access token anywhere within the application, use 
+`request.getAttribute(AlaOidcAuthenticator.JWT_ACCESS_TOKEN_ATTRIBUTE)`.
 
 ### Legacy Usage
 
@@ -34,6 +42,7 @@ On the server side, annotate protected controllers (either the class or individu
 - ```security.jwt.connect-timeout-ms``` - HTTP request connection timeout
 - ```security.jwt.read-timeout-ms``` - HTTP request read timeout
 - ```security.jwt.required-claims``` - The claims that must be present on the JWT for it to be valid.  By default this is `"sub", "iat", "exp", "nbf", "cid", "jti"`
+- ```security.jwt.prohibited-claims``` - The claims that must *not* be present on the JWT for it to be valid.  By default this is empty, ie no claims are prohibited.
 - ```security.jwt.required-scopes``` - List of scopes that are required for all JWT endpoints in this app
 - ```security.jwt.user-id-claim``` - The claims from the access token that contains the userId (default: `userid`)
 - ```security.jwt.role-claims``` - The name of the claim(s) that contain the roles (default: `role`)
@@ -41,6 +50,7 @@ On the server side, annotate protected controllers (either the class or individu
 - ```security.jwt.roles-from-access-token``` - should the role claims be read from the access_token (default: `true`)
 - ```security.jwt.role-prefix``` - The prefix to apply to the access token roles (eg. `ROLE_`)
 - ```security.jwt.role-to-uppercase``` - Should the role be converted to upper case (default: `true`)
+- ```security.jwt.accepted-audiences``` - If provided then only these audience values will be accepted. If not provided then any audience will be accepted.
 
 ### ApiKey support
 - ```security.apikey.enabled``` - Defaults to false. True indicated the plugin should check for apikey on incoming requests.

--- a/ala-ws-security-plugin/src/main/groovy/au/ala/org/ws/security/RequireApiKey.groovy
+++ b/ala-ws-security-plugin/src/main/groovy/au/ala/org/ws/security/RequireApiKey.groovy
@@ -31,4 +31,12 @@ import java.lang.annotation.Target
      * @return
      */
     String[] scopes() default []
+
+    /**
+     * Provide a Grails configuration property name to get the scopes from.  Combined with security.jwt.scopes and scopes parameter
+     * @return
+     */
+    String[] scopesFromProperty() default []
+
+    boolean useCustomFilter() default false
 }

--- a/ala-ws-security-plugin/src/main/groovy/au/ala/org/ws/security/filter/RequireApiKeyFilter.java
+++ b/ala-ws-security-plugin/src/main/groovy/au/ala/org/ws/security/filter/RequireApiKeyFilter.java
@@ -1,0 +1,18 @@
+package au.ala.org.ws.security.filter;
+
+import au.ala.org.ws.security.RequireApiKey;
+import grails.web.api.ServletAttributes;
+
+@FunctionalInterface
+public interface RequireApiKeyFilter {
+
+    /**
+     * Check if the request is allowed to proceed based on the annotation and the servlet attributes.
+     *
+     * @param annotation the annotation
+     * @param servletAttributes This will probably be the interceptor instance
+     * @return true if the request is allowed to proceed
+     */
+    boolean isAllowed(RequireApiKey annotation, ServletAttributes servletAttributes);
+
+}

--- a/ala-ws-security/src/main/java/au/org/ala/ws/security/AlaWsSecurityConfiguration.java
+++ b/ala-ws-security/src/main/java/au/org/ala/ws/security/AlaWsSecurityConfiguration.java
@@ -124,8 +124,11 @@ public class AlaWsSecurityConfiguration {
         authenticator.setKeySource(jwkSource);
         authenticator.setAuthorizationGenerator(new FromAttributesAuthorizationGenerator(jwtProperties.getRoleClaims(), jwtProperties.getPermissionClaims()));
 
+        authenticator.setAcceptedAudiences(jwtProperties.getAcceptedAudiences());
+
         authenticator.setUserIdClaim(jwtProperties.getUserIdClaim());
         authenticator.setRequiredClaims(jwtProperties.getRequiredClaims());
+        authenticator.setProhibitedClaims(jwtProperties.getProhibitedClaims());
         authenticator.setRequiredScopes(jwtProperties.getRequiredScopes());
 
         authenticator.setRolesFromAccessToken(jwtProperties.isRolesFromAccessToken());

--- a/ala-ws-security/src/main/java/au/org/ala/ws/security/JwtProperties.java
+++ b/ala-ws-security/src/main/java/au/org/ala/ws/security/JwtProperties.java
@@ -4,6 +4,7 @@ import org.pac4j.core.context.HttpConstants;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
+import java.util.Set;
 
 @ConfigurationProperties(value = "security.jwt")
 public class JwtProperties {
@@ -24,8 +25,11 @@ public class JwtProperties {
 
     private String userIdClaim = "userid";
     private List<String> requiredClaims = List.of("sub", "iat", "exp", "client_id", "jti", "iss");
+    private List<String> prohibitedClaims = List.of();
     private List<String> requiredScopes = List.of();
     private List<String> urlPatterns = List.of(); // hard coded paths to apply JWT authentication to
+
+    private Set<String> acceptedAudiences = Set.of();
 
     public String getClientId() {
         return clientId;
@@ -171,5 +175,21 @@ public class JwtProperties {
 
     public void setUrlPatterns(List<String> urlPatterns) {
         this.urlPatterns = urlPatterns;
+    }
+
+    public Set<String> getAcceptedAudiences() {
+        return acceptedAudiences;
+    }
+
+    public void setAcceptedAudiences(Set<String> acceptedAudiences) {
+        this.acceptedAudiences = acceptedAudiences;
+    }
+
+    public List<String> getProhibitedClaims() {
+        return prohibitedClaims;
+    }
+
+    public void setProhibitedClaims(List<String> prohibitedClaims) {
+        this.prohibitedClaims = prohibitedClaims;
     }
 }


### PR DESCRIPTION
 - Add reading @RequireApiKey required scopes from config
 - Add @RequireApiKey customisable authorisation
 - Add making the parsed access token JWT available to applications via request attribute
 - Add support for restricting audience values globally
 - Add support for prohibited claims
 - Add methods to allow client applications to clear user details caches