### PR TITLE
Work around for error on concurrent authentication

### DIFF
--- a/ala-auth/src/main/java/au/org/ala/pac4j/oidc/credentials/extractor/CognitoOidcExtractor.java
+++ b/ala-auth/src/main/java/au/org/ala/pac4j/oidc/credentials/extractor/CognitoOidcExtractor.java
@@ -6,6 +6,7 @@ import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.extractor.OidcCredentialsExtractor;
+import org.pac4j.oidc.exceptions.OidcStateMismatchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,7 @@ public class CognitoOidcExtractor extends OidcCredentialsExtractor {
             return super.extract(context);
         } catch (TechnicalException te) {
 
-            if (te.getMessage().equals("State cannot be determined")) {
+            if (te instanceof OidcStateMismatchException || te.getMessage().equals("State cannot be determined")) {
                 logger.error("State not found in session, please check session configuration.");
                 // redirect to the authentication page
                 throw client.getRedirectionAction(context).get();


### PR DESCRIPTION
When concurrent authentication attempts occur (which can happen when duplicating browser tabs) only one `state` value is handled by the author provider. This results in a `OidcStateMismatchException` when processing the auth callback. 

A workaround to deal with this occurrence is to redirect back to the auth provider. Which should result in a new authentication session. 

see https://atlaslivingaustralia.slack.com/lists/TBYSWJ9DZ/F07A0RXTRPZ?record_id=Rec08CEMVD4RK