### PR TITLE
Updated to pac4j 6.3.3 #58

### DIFF
--- a/ala-ws-security-plugin/src/test/groovy/au/org/ala/ws/security/AlaSecurityInterceptorSpec.groovy
+++ b/ala-ws-security-plugin/src/test/groovy/au/org/ala/ws/security/AlaSecurityInterceptorSpec.groovy
@@ -23,6 +23,7 @@ import groovy.time.TimeCategory
 import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.grails.web.util.GrailsApplicationAttributes
 import org.pac4j.core.config.Config
+import org.pac4j.core.credentials.authenticator.Authenticator
 import org.pac4j.core.exception.CredentialsException
 import org.pac4j.core.profile.creator.ProfileCreator
 import org.pac4j.http.client.direct.DirectBearerAuthClient
@@ -82,7 +83,9 @@ class AlaSecurityInterceptorSpec extends Specification implements InterceptorUni
         jwtAuthenticator.requiredClaims = []
         jwtAuthenticator.keySource = new ImmutableJWKSet<SecurityContext>(jwkSet)
 
-        oidcClient = new DirectBearerAuthClient(jwtAuthenticator, new AlaJwtProfileCreator(oidcConfiguration, new OidcClient()))
+        OidcClient mockClient = Mock()
+        mockClient.getAuthenticator() >> Authenticator.NEVER_VALIDATE // The initialisation of the OidcProfileCreator fails an assertion without this.
+        oidcClient = new DirectBearerAuthClient(jwtAuthenticator, new AlaJwtProfileCreator(oidcConfiguration, mockClient))
         apiKeyClient = new AlaApiKeyClient(new AlaApiKeyCredentialsExtractor(), alaApiKeyAuthenticator)
         ipAllowListClient = new IpClient(new IpAllowListAuthenticator(['2.2.2.2', '3.3.3.3']))
 

--- a/ala-ws-security/src/main/java/au/org/ala/ws/security/profile/creator/AlaJwtProfileCreator.java
+++ b/ala-ws-security/src/main/java/au/org/ala/ws/security/profile/creator/AlaJwtProfileCreator.java
@@ -256,7 +256,7 @@ public class AlaJwtProfileCreator extends OidcProfileCreator {
                                                       final Nonce nonce, UserProfile profile) {
         try {
             var accessTokenJwt = credentials.getJwtAccessToken();
-            var accessTokenClaims = configuration.getOpMetadataResolver().getTokenValidator().validate(accessTokenJwt, nonce);
+            var accessTokenClaims = configuration.getOpMetadataResolver().getTokenValidator().validateIdToken(accessTokenJwt, nonce);
 
             // add attributes of the access token if they don't already exist
             addClaimsToProfile(profile, accessTokenClaims);
@@ -283,7 +283,7 @@ public class AlaJwtProfileCreator extends OidcProfileCreator {
             var accessToken = credentials.toAccessToken();
             if (accessToken != null) {
                 var accessTokenJwt = JWTParser.parse(accessToken.getValue());
-                var accessTokenClaims = configuration.getOpMetadataResolver().getTokenValidator().validate(accessTokenJwt, nonce);
+                var accessTokenClaims = configuration.getOpMetadataResolver().getTokenValidator().validateIdToken(accessTokenJwt, nonce);
 
                 // add attributes of the access token if they don't already exist
                 addClaimsToProfile(profile, accessTokenClaims);

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,10 +12,10 @@ enableFeaturePreview('VERSION_CATALOGS')
 dependencyResolutionManagement {
     versionCatalogs {
         pac4j {
-            alias('oidc').to('org.pac4j:pac4j-oidc:6.0.6')
-            alias('jwt').to('org.pac4j:pac4j-jwt:6.0.6')
-            alias('http').to('org.pac4j:pac4j-http:6.0.6')
-            alias('jee').to('org.pac4j:pac4j-javaee:6.0.6')
+            alias('oidc').to('org.pac4j:pac4j-oidc:6.3.3')
+            alias('jwt').to('org.pac4j:pac4j-jwt:6.3.3')
+            alias('http').to('org.pac4j:pac4j-http:6.3.3')
+            alias('jee').to('org.pac4j:pac4j-javaee:6.3.3')
             alias('jee-support').to('org.pac4j:javaee-pac4j:8.0.1')
 //            alias('oidc').to('org.pac4j:pac4j-oidc:5.7.6')
 //            alias('jwt').to('org.pac4j:pac4j-jwt:5.7.6')


### PR DESCRIPTION
This upgrades to a pac4j 6.3.3 because of the recent CVE.  Note the ala-ws-security plugin wasn't vulnerable as it doesn't use the vulnerable JwtAuthenticator.

The upgrade has been tested with MERIT and ecodata for openidconnect interactive logins and JWT authorization via the Monitor app.
There was a change to the API introduced in pac4j 6.x - The TokenValidator validate method was replaced with two methods-> validateIdToken and validateLogoutToken to fix an error validating idTokens.
There was a behavioural change noted that required changes to integration tests.  The OidcProfileCreator no longer accepts an empty configuration and the eager initialisation of the OIDC discovery URI meant changes had to be made to provide a file based discovery URI so the integration test environment could startup.
